### PR TITLE
Fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ $ gammu-json send \
       "content": "This is a simple test message.",
       "result": "success"
      }
-    ]
+    ],
+    "result": "success"
   },
   {
     "parts_sent": 1,


### PR DESCRIPTION
Looks like you're missing a `success` in one of the examples.
